### PR TITLE
delayed signal must be usual signal in concurrent sentenses

### DIFF
--- a/distrib/sources/behvhdl/bvl_util.c
+++ b/distrib/sources/behvhdl/bvl_util.c
@@ -423,7 +423,10 @@ char *bvl_vectorize(char *name)
           sprintf (tmp1, "%s(%s)", new_name, &name[i+1]);
       }
       else
-        sprintf (tmp1, "%s'%s"  , new_name, &name[i+1]);
+        if (strcmp(&name[i+1], "delayed") == 0)
+           sprintf (tmp1, "%s_%s"  , new_name, &name[i+1]);
+        else
+           sprintf (tmp1, "%s'%s"  , new_name, &name[i+1]);
       new_name  = namealloc (tmp1);
     }
     beh_addtab(tab,name,NULL,BVL_PNTDFN,(long)new_name);


### PR DESCRIPTION
On vsclib check-lib and characterize, the generated vhdl file by Yagle had a syntax error.
This error is related to the delayed clock signal automatically detecting flip-flop.
The error sentence is as follows. The cp is the input signal and the "'delayed" attribute was converted to _delayed in the signal definition. The signal itself is not used in the flip-flop behavior expression but only in the presuming phase of the flip-flops. We can ignore the delayed sentence. We convert the 'delayed to _delayed to match the signal definition.

SIGNAL cp_delayed : STD_LOGIC;
BEGIN
  cp'delayed <= 'U';

